### PR TITLE
Confirm exit

### DIFF
--- a/sbcl-readline.lisp
+++ b/sbcl-readline.lisp
@@ -55,9 +55,15 @@
 |#
 
 (cffi:define-foreign-library ncurses 
+  (:darwin (:or (:default "/usr/local/opt/ncurses/lib/libncursesw") ; homebrew
+                (:default "/opt/local/lib/libncursesw") ; macports
+                (:default "libncursesw")))
                              (:windows "pdcurses.dll")
                              (t (:or "libncursesw.so.6" "libncursesw.so.5")))
 (cffi:define-foreign-library readline 
+  (:darwin (:or (:default "/usr/local/opt/readline/lib/libreadline") ; homebrew
+                (:default "/opt/local/lib/libreadline") ; macports
+                (:default "libreadline")))
                              (:windows (:or "readline.dll" "readline5.dll"))
                              (t (:or "libreadline.so.6")))
 


### PR DESCRIPTION
Add *eof-action* to prevent accidental exit from the REPL or to trigger some automatic action on exit.

Also, replaced the deprecated
`(sb-ext:quit)`
with
`(sb-thread:abort-thread :allow-exit t)`
Tested and works on multithreaded as well as unithreaded SBCL.