### PR TITLE
Ignore duplicates

### DIFF
--- a/sbcl-readline.lisp
+++ b/sbcl-readline.lisp
@@ -20,6 +20,7 @@
   (:export *complete*
            *history-file*
            *history-size*
+           *ignore-duplicates*
            *ps1*
            *ps2*
            *debug-ps1*
@@ -169,6 +170,12 @@
 (defvar *history-size* 200
   "Number of commands to keep in history")
 
+(defvar *ignore-duplicates* t
+  "If true, don't add line to history if it's the same as previous line")
+
+(defvar *previous-line* nil
+  "Keeps the previous line, to compare with the current for duplicate")
+
 (defvar *ps1* #'default-prompt
   "Either a string or a function that returns a string to be used when prompting user for the next command. The function has to take no arguments")
 
@@ -233,7 +240,11 @@
                              cmd
                              #.(make-string 1 :initial-element #\newline)
                              (read1 ps2)))))
-      (add-history cmd))))
+      (unless
+          (and *ignore-duplicates*
+               (equal cmd *previous-line*))
+        (setf *previous-line* cmd)
+        (add-history cmd)))))
 
 (defun parse-symbol (string &key (start 0) (end (length string)))
   (let* ((colon (position #\: string :start start :end end))

--- a/sbcl-readline.lisp
+++ b/sbcl-readline.lisp
@@ -55,9 +55,15 @@
 |#
 
 (cffi:define-foreign-library ncurses 
+  (:darwin (:or (:default "/usr/local/opt/ncurses/lib/libncursesw") ; homebrew
+                (:default "/opt/local/lib/libncursesw") ; macports
+                (:default "libncursesw")))
                              (:windows "pdcurses.dll")
                              (t (:or "libncursesw.so.6" "libncursesw.so.5")))
 (cffi:define-foreign-library readline 
+  (:darwin (:or (:default "/usr/local/opt/readline/lib/libreadline") ; homebrew
+                (:default "/opt/local/lib/libreadline") ; macports
+                (:default "libreadline")))
                              (:windows (:or "readline.dll" "readline5.dll"))
                              (t (:or "libreadline.so.6")))
 

--- a/sbcl-readline.lisp
+++ b/sbcl-readline.lisp
@@ -241,8 +241,9 @@
                              #.(make-string 1 :initial-element #\newline)
                              (read1 ps2)))))
       (unless
-          (and *ignore-duplicates*
-               (equal cmd *previous-line*))
+          (or (zerop (length cmd))
+              (and *ignore-duplicates*
+                   (equal cmd *previous-line*)))
         (setf *previous-line* cmd)
         (add-history cmd)))))
 


### PR DESCRIPTION
Added choice to ignore duplicates and empty lines from being added to history.
Empty lines are always ignored. The duplicate check is activated by default, but if one wants duplicates to be added to history, one can add
`(setf readline:*ignore-duplicates* nil)`
to .sbclrc

(I wanted the additions `'(darwin confirm-exit ignore-duplicates)` to be separate requests, so each could be chosen to be merged or not, but it might have gotten a bit messy this way. Apologies for that.)